### PR TITLE
[4] Bright posters' bounds are barely visible

### DIFF
--- a/page/landing-page/src/main/java/com/zappyware/moviebrowser/page/landing/MovieListScreen.kt
+++ b/page/landing-page/src/main/java/com/zappyware/moviebrowser/page/landing/MovieListScreen.kt
@@ -10,11 +10,15 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PageSize
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.dropShadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.shadow.Shadow
 import androidx.compose.ui.layout.WindowInsetsRulers
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -59,9 +63,16 @@ fun MovieListScreenUI(
             state = pagerState,
             modifier = Modifier.fillMaxWidth(),
             contentPadding = PaddingValues(16.dp, vertical = 0.dp),
-            pageSize = PageSize.Fixed(208.dp),
+            pageSize = PageSize.Fixed(224.dp),
         ) { pageIndex ->
             MovieListItem(
+                modifier = Modifier.dropShadow(
+                    shape = RoundedCornerShape(24.dp),
+                    shadow = Shadow(
+                        radius = 16.dp,
+                        color = Color.DarkGray
+                    ),
+                ),
                 movie = movies.value[pageIndex],
                 onDetailsClicked,
             )

--- a/page/landing-page/src/main/java/com/zappyware/moviebrowser/page/landing/composable/MovieListItem.kt
+++ b/page/landing-page/src/main/java/com/zappyware/moviebrowser/page/landing/composable/MovieListItem.kt
@@ -36,15 +36,15 @@ import com.zappyware.moviebrowser.data.Movie
 
 @Composable
 fun MovieListItem(
+    modifier: Modifier,
     movie: Movie,
     onDetailsClicked: (Movie) -> Unit,
 ) {
     Box(
-        modifier = Modifier
-            .size(196.dp, 270.dp)
+        modifier = Modifier.size(196.dp, 270.dp)
             .clickable {
                 onDetailsClicked(movie)
-            },
+            }.then(modifier),
     ) {
         AsyncImage(
             model = movie.smallCoverUrl,


### PR DESCRIPTION
Added drop shadow behind the pages to ensure proper poster bound visibility.

<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/50da1626-aa8b-4213-85ba-70c335530da1" />
